### PR TITLE
GH-2 Add support for optional working directory parameter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -126,3 +126,18 @@ jobs:
         run: test "$CHECK_RESULT" = "failure"
         env:
           CHECK_RESULT: ${{ steps.run-check.outputs.lockfile-check-result }}
+
+  # Test using a custom working directory.
+  test-custom-working-directory:
+    runs-on: ubuntu-latest
+    name: Test custom working directory
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Create nested dummy yarn.lock file
+        run: mkdir -p nested/directory && touch nested/directory/yarn.lock
+      - name: Run lockfile check action
+        uses: ./
+        with:
+          package-manager: yarn
+          working-directory: nested/directory

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,7 +71,7 @@ jobs:
   # - package-loock.json does not exist
   test-yarn-success:
     runs-on: ubuntu-latest
-    name: Test successful npm check
+    name: Test successful yarn check
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ and avoid a scenario where more than one lockfile is present.
     `yarn.lock` file is present.
   - `yarn`: Ensure that a `yarn.lock` file is present and that no
     `package-lock.json` file is present.
+- **`working-directory` (optional):** The path to the directory where the
+  lockfile check should occur, relative from the project root. e.g.
+  `web/themes/custom/my-custom-theme`
 
 ## Usage
 
@@ -27,7 +30,7 @@ To use this action, simply add a step to your workflow, like so:
 ```
 
 Here’s an example workflow that checks out your repo and checks that you have
-the correct lockfile for Yarn:
+the correct lockfile for Yarn within a custom theme for a Drupal project:
 
 ```yaml
 on: push
@@ -42,4 +45,5 @@ jobs:
         uses: ChromaticHQ/javascript-lockfile-check-action@v1.1.0
         with:
           package-manager: yarn
+          working-directory: web/themes/custom/my-custom-theme
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To use this action, simply add a step to your workflow, like so:
 ```
 
 Here’s an example workflow that checks out your repo and checks that you have
-the correct lockfile for Yarn within a custom theme for a Drupal project:
+the correct lockfile for Yarn within a custom theme for a CMS-based project:
 
 ```yaml
 on: push

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: 'The package manager you use'
     required: true
     default: 'npm'
+  working-directory:
+    description: 'An optional working directory, relative to the root of the project'
+    default: './'
 outputs:
   lockfile-check-result:
     description: 'The results of the check; can be `success` or `failure`.'
@@ -17,3 +20,4 @@ runs:
   image: 'Dockerfile'
   args:
     - ${{ inputs.package-manager }}
+    - ${{ inputs.working-directory }}

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: true
     default: 'npm'
   working-directory:
-    description: 'An optional working directory, relative to the root of the project'
+    description: 'An optional working directory, relative to the project root'
     default: './'
 outputs:
   lockfile-check-result:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,9 @@ emit_error()
   echo "::set-output name=lockfile-check-result::failure" && exit 1
 }
 
+# Change to the working directory (default is `./`).
+cd "$2"
+
 if [ "$1" = "npm" ]; then
   test -f "package-lock.json" || (echo "Error! Expected a package-lock.json file but none was found." && emit_error)
   test ! -f "yarn.lock" || (echo "Error! Extraneous yarn.lock file was found." && emit_error)


### PR DESCRIPTION
## Description
This PR adds support for an optional `working-directory` parameter which, if present, will cause the action to run tests in a directory nested within a project instead of the root of the project.

## Motivation / Context
Many projects use npm/Yarn within a directory nested in a project (as opposed to the root of the project). Some examples:
- CMS-based projects with a theme directory somewhere within its structure (e.g. Drupal or Wordpress).
- mono-repos with server and client code in the same project in separate directories

See #2.

## Testing Instructions / How This Has Been Tested
The PR includes a test case, which should pass.

## Screenshots
n/a

## Documentation
- [x] Add documentation about this feature to the README.
